### PR TITLE
Revert "Commenting out NCC"

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,12 +232,7 @@
         committee chair. If there are no members currently in the committee, contact our board
         members to get more info about chairing the committee.</p>
       <p>For a full list of committee members, see <a href="https://github.com/Wyndham-Forest-HOA/Wyndham-Forest-HOA/raw/master/documents/WFHOA_FAQ.pdf" target="_blank">our neighborhood FAQ document</a>.</p>
-      <!--
-        For some reason, someone is asking Limba to remove the NCC from our list of committees.
-        We don't understand why. Its still a real committee in our neighborhood. Commenting out
-        for now.
-      -->
-      <!--div class="sub-header">New Construction Committee (NCC)</div>
+      <div class="sub-header">New Construction Committee (NCC)</div>
       <p>The New Construction Committee (NCC) consists entirely of employees of <a href="https://www.hhhunt.com" target="_blank">HHHunt</a>.
         To reach the NCC, contact <a href="javascript:goto('modifications-committee');">the Modifications Committee</a>.</p>
       <p>The powers of the new construction committee are defined in Article XII (<span style="font-style: italic">Architectual Standards</span>),
@@ -253,7 +248,7 @@
         Design Guidelines from time to time without the consent of any
         Owner.
       </div>
-      <p></p-->
+      <p></p>
       <div id="modifications-committee" class="anchor"></div>
       <div class="sub-header">Modifications Committee (MC)</div>
       <div class="contact">


### PR DESCRIPTION
This reverts commit c2aa0c1e6247b5b8a2d8c1329cdbdc3a3f4d85ae. After
discussing this via email, it appears that commit was a result of
Jagan misunderstanding our New Construction Committee.